### PR TITLE
fix: use createWebHashHistory instead of createMemoryHistory in router

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-1-router-history.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-1-router-history.md
@@ -1,0 +1,38 @@
+---
+node: issue-1-router-history
+worker: implementer
+date: 2026-08-20
+---
+
+## Task
+Fix [issue #1](https://github.com/datvt243/vue-resume-web/issues/1) — router dùng
+`createMemoryHistory`, URL không đổi trên browser, mất route khi refresh.
+
+## Diff
+`src/routers/index.js`:
+- import `createWebHashHistory` thay vì `createMemoryHistory`
+- `history: createWebHashHistory()` thay vì `createMemoryHistory()`
+
+Diff nhỏ nhất, 2 dòng, đúng như fix đề xuất trong issue (phù hợp GitHub Pages,
+không cần server config).
+
+## Build output (npm run build) — đọc lại nguyên văn
+```
+> vue-resume-web@0.0.0 build
+> vite build
+
+vite v5.3.2 building for production...
+transforming...
+✓ 1340 modules transformed.
+...
+✓ built in 4.78s
+```
+Build xanh, không lỗi. (Không có test suite thật — xem doctrine/MEMORY.md.
+Đây là build-only evidence, không phải test thật.)
+
+Ghi chú: có 1 TS diagnostic tồn tại từ trước ở dòng 82 (`'from' is declared
+but its value is never read`) — không liên quan tới thay đổi này, không sửa
+vì ngoài phạm vi issue #1.
+
+## Trạng thái
+sealed_pending_verifier

--- a/agent-hub/evidence/verifier/2026-08-20-issue-1-router-history.md
+++ b/agent-hub/evidence/verifier/2026-08-20-issue-1-router-history.md
@@ -1,0 +1,22 @@
+---
+node: issue-1-router-history
+worker: verifier
+date: 2026-08-20
+verdict: SEAL
+---
+
+## Acceptance criteria checked
+1. Diff trace về đúng 1 node (issue-1-router-history) — OK.
+2. Diff nhỏ nhất: chỉ đổi `createMemoryHistory` → `createWebHashHistory` ở
+   2 chỗ (import + `history:` option), khớp chính xác cách fix đề xuất
+   trong [issue #1](https://github.com/datvt243/vue-resume-web/issues/1) —
+   OK, không có thay đổi thừa (đã tự `git diff main -- src/routers/index.js`
+   để đọc lại, không suy luận từ evidence note).
+3. `npm run build` — đã tự chạy lại độc lập, output kết thúc
+   `✓ built in Xs`, không có dòng lỗi. Build-only evidence (không phải test
+   thật) — đúng như ghi chú trong evidence note của implementer.
+4. Evidence note implementer tồn tại tại
+   `evidence/implementer/2026-08-20-issue-1-router-history.md`.
+
+## Verdict
+SEAL — đủ điều kiện theo NORTHSTAR.md.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -40,6 +40,7 @@ flowchart TD
 | Node | State | Notes |
 |---|---|---|
 | `hub-init` | PENDING | Placeholder — chưa có task thật nào chạy qua `/worker` sau khi hub được khởi tạo (2026-08-20). Việc khởi tạo hub bản thân nó nằm NGOÀI vòng implementer/verifier (bootstrap một lần), nên không tự SEAL — node đầu tiên sẽ do `/worker implementer "<task>"` thật tạo ra qua `pick_next`. |
+| `issue-1-router-history` | SEALED | [issue #1](https://github.com/datvt243/vue-resume-web/issues/1) — `createMemoryHistory` → `createWebHashHistory`. Evidence: `evidence/implementer/2026-08-20-issue-1-router-history.md`, `evidence/verifier/2026-08-20-issue-1-router-history.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.

--- a/src/routers/index.js
+++ b/src/routers/index.js
@@ -4,7 +4,7 @@
  * Description:
  */
 
-import { createMemoryHistory, createRouter } from 'vue-router'
+import { createWebHashHistory, createRouter } from 'vue-router'
 import { authStore } from '@/stores/auth'
 
 const routes = [
@@ -75,7 +75,7 @@ const routes = [
 ]
 
 const router = createRouter({
-    history: createMemoryHistory(),
+    history: createWebHashHistory(),
     routes,
 })
 


### PR DESCRIPTION
## Summary
- `createMemoryHistory` keeps navigation state in RAM and never touches the browser URL, so refreshing the page loses the route, URLs can't be bookmarked/shared, and back/forward misbehave.
- Switched to `createWebHashHistory`, which needs no extra server config — matches the GitHub Pages deploy target.

Closes #1

## Test plan
- [x] `npm run build` — green (build-only evidence, no test suite in this repo yet — see agent-hub/doctrine/MEMORY.md)
- [x] Evidence notes: `agent-hub/evidence/implementer/2026-08-20-issue-1-router-history.md`, `agent-hub/evidence/verifier/2026-08-20-issue-1-router-history.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)