### PR TITLE
fix: send login credentials via POST body instead of GET query params

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-2-login-post.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-2-login-post.md
@@ -1,0 +1,39 @@
+---
+node: issue-2-login-post
+worker: implementer
+date: 2026-08-20
+---
+
+## Task
+Fix [issue #2](https://github.com/datvt243/vue-resume-web/issues/2) — login
+gửi password qua GET query params, lộ trong browser history / server logs
+(OWASP A02:2021).
+
+## Diff
+`src/services/auth.js` `handleLogin`:
+- `method: 'get'` → `method: 'post'`
+- `params: {...}` → `data: {...}` (request body thay vì query string)
+
+Diff nhỏ nhất, đúng cách fix đề xuất trong issue.
+
+⚠️ Issue ghi rõ: "Backend cũng phải thay đổi để nhận POST body thay vì GET
+query params." Backend (`nodejs-resume-api-ts`) không nằm trong repo này —
+không thể verify phía backend đã chấp nhận POST chưa. Đây là giới hạn ngoài
+phạm vi sửa của repo frontend; ghi rõ trong PR.
+
+## Build output (npm run build) — đọc lại nguyên văn
+```
+> vue-resume-web@0.0.0 build
+> vite build
+...
+✓ built in 4.69s
+```
+Build xanh. Có 1 TS diagnostic tiền tồn tại, không liên quan tới diff này:
+`'tokenRefresh' is declared but its value is never read` (dòng 42) — đây là
+phạm vi của [issue #12](https://github.com/datvt243/vue-resume-web/issues/12),
+không sửa ở đây.
+
+Không có test suite thật (build-only evidence, xem doctrine/MEMORY.md).
+
+## Trạng thái
+sealed_pending_verifier

--- a/agent-hub/evidence/verifier/2026-08-20-issue-2-login-post.md
+++ b/agent-hub/evidence/verifier/2026-08-20-issue-2-login-post.md
@@ -1,0 +1,22 @@
+---
+node: issue-2-login-post
+worker: verifier
+date: 2026-08-20
+verdict: SEAL
+---
+
+## Acceptance criteria checked
+1. Trace về đúng 1 node (issue-2-login-post) — OK.
+2. Diff nhỏ nhất: `method: 'get'`→`'post'`, `params`→`data`, đúng cách fix
+   đề xuất trong [issue #2](https://github.com/datvt243/vue-resume-web/issues/2)
+   — tự `git diff main -- src/services/auth.js` để đọc lại, không suy luận.
+3. `npm run build` — tự chạy lại độc lập, kết thúc `✓ built in Xs`, không
+   lỗi. Build-only evidence, không phải test thật.
+4. Evidence note implementer tồn tại tại
+   `evidence/implementer/2026-08-20-issue-2-login-post.md`.
+5. Caveat backend (issue yêu cầu backend cũng phải nhận POST body) đã được
+   ghi rõ trong evidence note và sẽ ghi trong PR — đúng, đây là giới hạn
+   ngoài phạm vi repo frontend, không phải lỗi của diff này.
+
+## Verdict
+SEAL.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -41,6 +41,7 @@ flowchart TD
 |---|---|---|
 | `hub-init` | PENDING | Placeholder — chưa có task thật nào chạy qua `/worker` sau khi hub được khởi tạo (2026-08-20). Việc khởi tạo hub bản thân nó nằm NGOÀI vòng implementer/verifier (bootstrap một lần), nên không tự SEAL — node đầu tiên sẽ do `/worker implementer "<task>"` thật tạo ra qua `pick_next`. |
 | `issue-1-router-history` | SEALED | [issue #1](https://github.com/datvt243/vue-resume-web/issues/1) — `createMemoryHistory` → `createWebHashHistory`. Evidence: `evidence/implementer/2026-08-20-issue-1-router-history.md`, `evidence/verifier/2026-08-20-issue-1-router-history.md`. |
+| `issue-2-login-post` | SEALED | [issue #2](https://github.com/datvt243/vue-resume-web/issues/2) — login GET→POST, params→data. Backend cần chấp nhận POST body (ngoài phạm vi repo này). Evidence: `evidence/implementer/2026-08-20-issue-2-login-post.md`, `evidence/verifier/2026-08-20-issue-2-login-post.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -26,9 +26,9 @@ export const handleLogin = async (values, props) => {
      */
     try {
         await _axios({
-            method: 'get',
+            method: 'post',
             url: `${subURL}auth/login`,
-            params: {
+            data: {
                 email: email.trim(),
                 password: password.trim(),
             },


### PR DESCRIPTION
## Summary
- Login sent `email`/`password` as GET query params, so the password ended up in browser history, server access logs, proxy/CDN logs, and referrer headers (OWASP A02:2021).
- Switched to `method: 'post'` with `data` (request body).

⚠️ Backend must also accept POST body for `/auth/login` for this to work end-to-end — that change is outside this repo.

Closes #2

## Test plan
- [x] `npm run build` — green (build-only evidence, no test suite yet — see agent-hub/doctrine/MEMORY.md)
- [x] Evidence notes: `agent-hub/evidence/implementer/2026-08-20-issue-2-login-post.md`, `agent-hub/evidence/verifier/2026-08-20-issue-2-login-post.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)