### PR TITLE
fix: stop VeeForm from mutating props.fields via delete

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-3-veeform-mutate-props.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-3-veeform-mutate-props.md
@@ -1,0 +1,33 @@
+---
+node: issue-3-veeform-mutate-props
+worker: implementer
+date: 2026-08-20
+---
+
+## Task
+Fix [issue #3](https://github.com/datvt243/vue-resume-web/issues/3) —
+`VeeForm.vue:36` `delete e.valid` trong `.map()` mutate trực tiếp object
+gốc trong `props.fields` (props truyền theo reference) → validation mất sau
+lần mở modal đầu tiên.
+
+## Diff
+`src/components/veevalidate/VeeForm.vue` `getFields`:
+- `delete e.valid; return e` → destructure `const { valid: _valid, ...rest } = e; return rest`
+
+Đúng cách fix đề xuất trong issue — tạo object mới thay vì mutate.
+
+## Build output (npm run build) — đọc lại nguyên văn
+```
+> vue-resume-web@0.0.0 build
+> vite build
+...
+✓ built in 4.71s
+```
+Build xanh, không lỗi mới. Không có test suite thật (build-only evidence,
+xem doctrine/MEMORY.md). Repro steps trong issue (mở modal 2 lần) là
+manual UI check — không chạy `npm run dev` để click qua UI trong phiên này;
+diff là thay đổi thuần logic loại bỏ mutation, đối chiếu trực tiếp với mô
+tả bug trong issue.
+
+## Trạng thái
+sealed_pending_verifier

--- a/agent-hub/evidence/verifier/2026-08-20-issue-3-veeform-mutate-props.md
+++ b/agent-hub/evidence/verifier/2026-08-20-issue-3-veeform-mutate-props.md
@@ -1,0 +1,23 @@
+---
+node: issue-3-veeform-mutate-props
+worker: verifier
+date: 2026-08-20
+verdict: SEAL
+---
+
+## Acceptance criteria checked
+1. Trace về đúng 1 node (issue-3-veeform-mutate-props) — OK.
+2. Diff nhỏ nhất: thay `delete e.valid` bằng destructuring, không mutate
+   `props.fields` nữa — khớp cách fix đề xuất trong
+   [issue #3](https://github.com/datvt243/vue-resume-web/issues/3). Tự
+   `git diff main -- src/components/veevalidate/VeeForm.vue` để đọc lại.
+3. `npm run build` — tự chạy lại độc lập, `✓ built in Xs`, không lỗi.
+   Build-only evidence.
+4. Evidence note implementer tồn tại tại
+   `evidence/implementer/2026-08-20-issue-3-veeform-mutate-props.md`, có
+   ghi rõ không chạy UI manual check (`npm run dev`) trong phiên này —
+   chấp nhận được vì đây là bug logic thuần (loại bỏ mutation), diff đối
+   chiếu trực tiếp với repro steps mô tả trong issue.
+
+## Verdict
+SEAL.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -42,6 +42,7 @@ flowchart TD
 | `hub-init` | PENDING | Placeholder — chưa có task thật nào chạy qua `/worker` sau khi hub được khởi tạo (2026-08-20). Việc khởi tạo hub bản thân nó nằm NGOÀI vòng implementer/verifier (bootstrap một lần), nên không tự SEAL — node đầu tiên sẽ do `/worker implementer "<task>"` thật tạo ra qua `pick_next`. |
 | `issue-1-router-history` | SEALED | [issue #1](https://github.com/datvt243/vue-resume-web/issues/1) — `createMemoryHistory` → `createWebHashHistory`. Evidence: `evidence/implementer/2026-08-20-issue-1-router-history.md`, `evidence/verifier/2026-08-20-issue-1-router-history.md`. |
 | `issue-2-login-post` | SEALED | [issue #2](https://github.com/datvt243/vue-resume-web/issues/2) — login GET→POST, params→data. Backend cần chấp nhận POST body (ngoài phạm vi repo này). Evidence: `evidence/implementer/2026-08-20-issue-2-login-post.md`, `evidence/verifier/2026-08-20-issue-2-login-post.md`. |
+| `issue-3-veeform-mutate-props` | SEALED | [issue #3](https://github.com/datvt243/vue-resume-web/issues/3) — `delete e.valid` → destructuring, hết mutate `props.fields`. Evidence: `evidence/implementer/2026-08-20-issue-3-veeform-mutate-props.md`, `evidence/verifier/2026-08-20-issue-3-veeform-mutate-props.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.

--- a/src/components/veevalidate/VeeForm.vue
+++ b/src/components/veevalidate/VeeForm.vue
@@ -33,8 +33,8 @@ const props = defineProps({
 
 const getFields = computed(() => {
     return props.fields.map(e => {
-        delete e.valid
-        return e
+        const { valid: _valid, ...rest } = e
+        return rest
     })
 })
 const getFieldId = computed(() => {


### PR DESCRIPTION
## Summary
- `getFields` computed ran `delete e.valid` inside `.map()`, mutating the field objects in `props.fields` directly (props are references, not copies). After the first render, `valid` was permanently gone from the parent's field definitions — closing and reopening a modal lost validation.
- Replaced with destructuring to build a new object per field instead of mutating in place.

Closes #3

## Test plan
- [x] `npm run build` — green (build-only evidence, no test suite yet — see agent-hub/doctrine/MEMORY.md)
- [x] Evidence notes: `agent-hub/evidence/implementer/2026-08-20-issue-3-veeform-mutate-props.md`, `agent-hub/evidence/verifier/2026-08-20-issue-3-veeform-mutate-props.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)