### PR TITLE
fix: correct typo and reduce logic in VeeForm reset()

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-4-veeform-reset-typo.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-4-veeform-reset-typo.md
@@ -1,0 +1,35 @@
+---
+node: issue-4-veeform-reset-typo
+worker: implementer
+date: 2026-08-20
+---
+
+## Task
+Fix [issue #4](https://github.com/datvt243/vue-resume-web/issues/4) —
+`VeeForm.vue:93` typo `e.nam` (đáng lẽ `e.name`) trong `reset()`, cộng thêm
+`reduce` thiếu `initialValue` nên không tích lũy đúng (overwrite thay vì
+merge) và dùng sai key `errors:` thay vì `values:`.
+
+## Diff
+`src/components/veevalidate/VeeForm.vue` `reset()`:
+- `errors: getFields.value.reduce((obj, e) => ({ [e.nam]: '' }))` →
+  `values: getFields.value.reduce((obj, e) => ({ ...obj, [e.name]: '' }), {})`
+
+Áp dụng đúng cách fix đề xuất trong issue: sửa typo, thêm `initialValue`
+`{}`, spread `...obj` để tích lũy đúng, đổi `errors` → `values` (reset field
+values, không phải set lỗi giả).
+
+## Build output (npm run build) — đọc lại nguyên văn
+```
+> vue-resume-web@0.0.0 build
+> vite build
+...
+✓ built in 4.76s
+```
+Build xanh, không lỗi. Build-only evidence (không có test suite thật —
+xem doctrine/MEMORY.md). Không chạy `npm run dev` để click qua modal
+"Thêm mới" trong phiên này — diff đối chiếu trực tiếp với repro/fix mô tả
+trong issue (typo + reduce logic).
+
+## Trạng thái
+sealed_pending_verifier

--- a/agent-hub/evidence/verifier/2026-08-20-issue-4-veeform-reset-typo.md
+++ b/agent-hub/evidence/verifier/2026-08-20-issue-4-veeform-reset-typo.md
@@ -1,0 +1,20 @@
+---
+node: issue-4-veeform-reset-typo
+worker: verifier
+date: 2026-08-20
+verdict: SEAL
+---
+
+## Acceptance criteria checked
+1. Trace về đúng 1 node (issue-4-veeform-reset-typo) — OK.
+2. Diff nhỏ nhất: sửa `e.nam`→`e.name`, thêm `initialValue` `{}`, spread để
+   merge đúng, `errors:`→`values:` — khớp chính xác cách fix đề xuất trong
+   [issue #4](https://github.com/datvt243/vue-resume-web/issues/4). Tự
+   `git diff main -- src/components/veevalidate/VeeForm.vue` để đọc lại.
+3. `npm run build` — tự chạy lại độc lập, `✓ built in Xs`, không lỗi.
+   Build-only evidence.
+4. Evidence note implementer tồn tại tại
+   `evidence/implementer/2026-08-20-issue-4-veeform-reset-typo.md`.
+
+## Verdict
+SEAL.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -43,6 +43,7 @@ flowchart TD
 | `issue-1-router-history` | SEALED | [issue #1](https://github.com/datvt243/vue-resume-web/issues/1) — `createMemoryHistory` → `createWebHashHistory`. Evidence: `evidence/implementer/2026-08-20-issue-1-router-history.md`, `evidence/verifier/2026-08-20-issue-1-router-history.md`. |
 | `issue-2-login-post` | SEALED | [issue #2](https://github.com/datvt243/vue-resume-web/issues/2) — login GET→POST, params→data. Backend cần chấp nhận POST body (ngoài phạm vi repo này). Evidence: `evidence/implementer/2026-08-20-issue-2-login-post.md`, `evidence/verifier/2026-08-20-issue-2-login-post.md`. |
 | `issue-3-veeform-mutate-props` | SEALED | [issue #3](https://github.com/datvt243/vue-resume-web/issues/3) — `delete e.valid` → destructuring, hết mutate `props.fields`. Evidence: `evidence/implementer/2026-08-20-issue-3-veeform-mutate-props.md`, `evidence/verifier/2026-08-20-issue-3-veeform-mutate-props.md`. |
+| `issue-4-veeform-reset-typo` | SEALED | [issue #4](https://github.com/datvt243/vue-resume-web/issues/4) — `e.nam`→`e.name`, sửa `reduce` thiếu initialValue, `errors:`→`values:`. Evidence: `evidence/implementer/2026-08-20-issue-4-veeform-reset-typo.md`, `evidence/verifier/2026-08-20-issue-4-veeform-reset-typo.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.

--- a/src/components/veevalidate/VeeForm.vue
+++ b/src/components/veevalidate/VeeForm.vue
@@ -90,7 +90,7 @@ defineExpose({
 
 function reset() {
     resetForm({
-        errors: getFields.value.reduce((obj, e) => ({ [e.nam]: '' })),
+        values: getFields.value.reduce((obj, e) => ({ ...obj, [e.name]: '' }), {}),
     })
 }
 


### PR DESCRIPTION
## Summary
- `e.nam` was undefined, so every error key collapsed to `"undefined"`, and the missing `reduce` initialValue meant only the last field survived instead of accumulating. Net effect: errors from a previous "create" submit stuck around every time the modal reopened.
- Fixed the typo (`e.name`), added the `{}` initialValue, spread to accumulate correctly, and reset `values` instead of writing to `errors`.

Closes #4

## Test plan
- [x] `npm run build` — green (build-only evidence, no test suite yet — see agent-hub/doctrine/MEMORY.md)
- [x] Evidence notes: `agent-hub/evidence/implementer/2026-08-20-issue-4-veeform-reset-typo.md`, `agent-hub/evidence/verifier/2026-08-20-issue-4-veeform-reset-typo.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)