### PR TITLE
fix: remove v-html XSS vector from Toasts

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-5-xss-vhtml-toast.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-5-xss-vhtml-toast.md
@@ -1,0 +1,43 @@
+---
+node: issue-5-xss-vhtml-toast
+worker: implementer
+date: 2026-08-20
+---
+
+## Task
+Fix [issue #5](https://github.com/datvt243/vue-resume-web/issues/5) — XSS:
+`Toasts.vue:44` render `v-html="props.content"` từ error message server,
+không sanitize (OWASP A03:2021). Kết hợp `services/base.js` build message
+bằng `<br />` HTML tag nối vào string.
+
+## Diff
+- `src/components/Toasts.vue`: `v-html="props.content"` → text
+  interpolation `{{ props.content }}`, thêm `style="white-space: pre-line"`
+  để giữ format xuống dòng (thay cho `<br />` cũ, vì message được join bằng
+  `\n`).
+- `src/services/base.js`: bỏ `<br />` khỏi `_message.push(...)` (không cần
+  nữa vì `white-space: pre-line` đã render `\n` thành dòng mới, và tránh
+  chuỗi có literal `<br />` hiện ra dạng text sau khi bỏ `v-html`).
+
+Chọn Option 1 trong issue (bỏ `v-html`, không cần thêm dependency
+DOMPurify) — diff nhỏ nhất, loại hoàn toàn vector XSS thay vì chỉ giảm rủi
+ro qua sanitize.
+
+Đã `grep -rn "v-html" src/` — còn 2 chỗ khác (`ItemTemplate.vue` render
+CKEditor description, `Dropdown.vue` render `props.text` tự viết trong
+code, không phải error message thô từ server) — ngoài phạm vi issue #5,
+không sửa.
+
+## Build output (npm run build) — đọc lại nguyên văn
+```
+> vue-resume-web@0.0.0 build
+> vite build
+...
+✓ built in 4.55s
+```
+Build xanh. Có 4 TS diagnostic tiền tồn tại trong `base.js` (unused `key`,
+`props`, `callback`, destructure) — không liên quan tới diff này, không sửa
+(ngoài phạm vi issue #5). Build-only evidence — không có test suite thật.
+
+## Trạng thái
+sealed_pending_verifier

--- a/agent-hub/evidence/verifier/2026-08-20-issue-5-xss-vhtml-toast.md
+++ b/agent-hub/evidence/verifier/2026-08-20-issue-5-xss-vhtml-toast.md
@@ -1,0 +1,25 @@
+---
+node: issue-5-xss-vhtml-toast
+worker: verifier
+date: 2026-08-20
+verdict: SEAL
+---
+
+## Acceptance criteria checked
+1. Trace về đúng 1 node (issue-5-xss-vhtml-toast) — OK.
+2. Diff nhỏ nhất, đúng Option 1 trong
+   [issue #5](https://github.com/datvt243/vue-resume-web/issues/5): bỏ
+   `v-html` khỏi `Toasts.vue`, loại `<br />` HTML khỏi message construction
+   trong `base.js`. Tự `git diff main -- src/components/Toasts.vue
+   src/services/base.js` để đọc lại — xác nhận không còn `v-html` nào nhận
+   `props.content` (server error message).
+3. Đã tự `grep -rn "v-html" src/` — xác nhận 2 usage còn lại
+   (`ItemTemplate.vue`, `Dropdown.vue`) không liên quan tới error message
+   từ server, đúng như evidence note ghi, không phải regression.
+4. `npm run build` — tự chạy lại độc lập, `✓ built in Xs`, không lỗi mới.
+   Build-only evidence.
+5. Evidence note implementer tồn tại tại
+   `evidence/implementer/2026-08-20-issue-5-xss-vhtml-toast.md`.
+
+## Verdict
+SEAL.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -44,6 +44,7 @@ flowchart TD
 | `issue-2-login-post` | SEALED | [issue #2](https://github.com/datvt243/vue-resume-web/issues/2) — login GET→POST, params→data. Backend cần chấp nhận POST body (ngoài phạm vi repo này). Evidence: `evidence/implementer/2026-08-20-issue-2-login-post.md`, `evidence/verifier/2026-08-20-issue-2-login-post.md`. |
 | `issue-3-veeform-mutate-props` | SEALED | [issue #3](https://github.com/datvt243/vue-resume-web/issues/3) — `delete e.valid` → destructuring, hết mutate `props.fields`. Evidence: `evidence/implementer/2026-08-20-issue-3-veeform-mutate-props.md`, `evidence/verifier/2026-08-20-issue-3-veeform-mutate-props.md`. |
 | `issue-4-veeform-reset-typo` | SEALED | [issue #4](https://github.com/datvt243/vue-resume-web/issues/4) — `e.nam`→`e.name`, sửa `reduce` thiếu initialValue, `errors:`→`values:`. Evidence: `evidence/implementer/2026-08-20-issue-4-veeform-reset-typo.md`, `evidence/verifier/2026-08-20-issue-4-veeform-reset-typo.md`. |
+| `issue-5-xss-vhtml-toast` | SEALED | [issue #5](https://github.com/datvt243/vue-resume-web/issues/5) — bỏ `v-html` khỏi Toasts.vue, bỏ `<br />` HTML khỏi base.js. Evidence: `evidence/implementer/2026-08-20-issue-5-xss-vhtml-toast.md`, `evidence/verifier/2026-08-20-issue-5-xss-vhtml-toast.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.

--- a/src/components/Toasts.vue
+++ b/src/components/Toasts.vue
@@ -41,7 +41,7 @@ function show() {
                         </span>
                     </span>
                 </div>
-                <div class="toast-body" v-html="props.content"></div>
+                <div class="toast-body" style="white-space: pre-line">{{ props.content }}</div>
             </div>
         </div>
     </div>

--- a/src/services/base.js
+++ b/src/services/base.js
@@ -90,7 +90,7 @@ const _helper = props => {
              */
             if (errors && Object.keys(errors).length) {
                 for (const [key, mess] of Object.entries(errors)) {
-                    _message.push(`<br />- ${mess} `)
+                    _message.push(`- ${mess} `)
                 }
             }
 


### PR DESCRIPTION
## Summary
- Server error messages were joined into an HTML string (`<br />- msg`) and rendered via `v-html`, so a compromised/MITM'd API response could inject a script tag straight into the page. Combined with the JWT sitting in `localStorage`, that's a token-theft path (OWASP A03:2021).
- Switched `Toasts.vue` to text interpolation with `white-space: pre-line` to keep the line-break formatting, and dropped the now-unneeded `<br />` tag from the message builder in `base.js`.
- Left the two other `v-html` usages in the codebase (`ItemTemplate.vue`, `Dropdown.vue`) alone — they render CKEditor/own-authored content, not raw server error messages, so out of scope for this issue.

Closes #5

## Test plan
- [x] `npm run build` — green (build-only evidence, no test suite yet — see agent-hub/doctrine/MEMORY.md)
- [x] Evidence notes: `agent-hub/evidence/implementer/2026-08-20-issue-5-xss-vhtml-toast.md`, `agent-hub/evidence/verifier/2026-08-20-issue-5-xss-vhtml-toast.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)