### PR TITLE
docs: record issue #8 (JWT in localStorage) as blocked on backend

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-8-jwt-localstorage-blocked.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-8-jwt-localstorage-blocked.md
@@ -1,0 +1,36 @@
+---
+node: issue-8-jwt-localstorage
+worker: implementer
+date: 2026-08-20
+status: BLOCKED_ON_BACKEND
+---
+
+## Task
+[Issue #8](https://github.com/datvt243/vue-resume-web/issues/8) — JWT lưu
+trong `localStorage` (`src/stores/auth.js:12-13`), đọc được bởi bất kỳ JS
+nào chạy trên trang nếu có XSS.
+
+## Vì sao KHÔNG fix trong phiên này
+Cách fix đúng theo issue là chuyển sang httpOnly cookie:
+```
+Set-Cookie: token=<jwt>; HttpOnly; Secure; SameSite=Strict; Path=/
+```
+Điều này đòi hỏi **backend** (`nodejs-resume-api-ts`, repo riêng, không nằm
+trong `vue-resume-web`) set cookie thay vì trả token trong response body,
+và frontend bỏ hẳn việc tự đọc/gắn `Authorization: Bearer <token>` — một
+thay đổi kiến trúc xuyên suốt `services/axios.js`, `stores/auth.js`, mọi
+`composables/useDocument.ts` gọi API.
+
+Không có quyền/khả năng sửa backend từ phiên này. Bất kỳ "fix" chỉ ở
+frontend (vd đổi sang `sessionStorage`) đều KHÔNG giải quyết root cause
+(vẫn đọc được qua JS nếu có XSS) — sẽ là một diff giả tạo cảm giác "đã
+fix" mà không đúng bản chất. Theo NORTHSTAR: claim khống = `EDIT_UNVERIFIED`.
+
+Issue #8 note đã ghi rõ: "Fix issue #5 (XSS) trước — nếu không có XSS thì
+risk của localStorage giảm đáng kể." → [issue #5](https://github.com/datvt243/vue-resume-web/issues/5)
+đã SEAL (xem `issue-5-xss-vhtml-toast` trên diagram), risk hiện tại đã giảm
+đáng kể dù chưa loại bỏ hoàn toàn.
+
+## Trạng thái
+Không tạo branch/PR — không có code thay đổi. Issue #8 giữ nguyên OPEN trên
+GitHub, cần task riêng có phối hợp backend.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -45,6 +45,7 @@ flowchart TD
 | `issue-3-veeform-mutate-props` | SEALED | [issue #3](https://github.com/datvt243/vue-resume-web/issues/3) — `delete e.valid` → destructuring, hết mutate `props.fields`. Evidence: `evidence/implementer/2026-08-20-issue-3-veeform-mutate-props.md`, `evidence/verifier/2026-08-20-issue-3-veeform-mutate-props.md`. |
 | `issue-4-veeform-reset-typo` | SEALED | [issue #4](https://github.com/datvt243/vue-resume-web/issues/4) — `e.nam`→`e.name`, sửa `reduce` thiếu initialValue, `errors:`→`values:`. Evidence: `evidence/implementer/2026-08-20-issue-4-veeform-reset-typo.md`, `evidence/verifier/2026-08-20-issue-4-veeform-reset-typo.md`. |
 | `issue-5-xss-vhtml-toast` | SEALED | [issue #5](https://github.com/datvt243/vue-resume-web/issues/5) — bỏ `v-html` khỏi Toasts.vue, bỏ `<br />` HTML khỏi base.js. Evidence: `evidence/implementer/2026-08-20-issue-5-xss-vhtml-toast.md`, `evidence/verifier/2026-08-20-issue-5-xss-vhtml-toast.md`. |
+| `issue-8-jwt-localstorage` | BLOCKED_ON_BACKEND | [issue #8](https://github.com/datvt243/vue-resume-web/issues/8) — cần backend set httpOnly cookie, ngoài phạm vi repo frontend. Không tạo diff giả. Issue giữ OPEN. Evidence: `evidence/implementer/2026-08-20-issue-8-jwt-localstorage-blocked.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.


### PR DESCRIPTION
## Summary
- Issue #8 asks to move the JWT out of `localStorage`. The real fix is the backend setting an httpOnly cookie instead of returning the token in the response body, plus the frontend dropping manual `Authorization` header attachment — that's a backend change outside this repo.
- Recorded this as `BLOCKED_ON_BACKEND` in the agent-hub diagram/evidence rather than shipping a frontend-only swap (e.g. to `sessionStorage`) that wouldn't address the actual root cause (still readable via JS if XSS exists).
- Issue #8 itself stays open on GitHub — no source code changed.

## Test plan
- N/A — no application code changed, doc/evidence only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)