### PR TITLE
fix: keep spinner loading ref reactive through useHelper

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-9-usehelper-reactive-loading.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-9-usehelper-reactive-loading.md
@@ -1,0 +1,41 @@
+---
+node: issue-9-usehelper-reactive-loading
+worker: implementer
+date: 2026-08-20
+---
+
+## Task
+Fix [issue #9](https://github.com/datvt243/vue-resume-web/issues/9) —
+`useHelper.js:14` `toValue(refSpinner)` snapshot giá trị Ref một lần lúc
+`setup()`, nếu `refSpinner.value` là `null` lúc đó thì `loading` mãi mãi
+`null` → spinner không hiển thị.
+
+## Diff
+- `src/composables/useHelper.js`: trả về Ref `refSpinner` thay vì
+  `toValue(refSpinner)` snapshot.
+- `src/services/base.js` (`handleFrameFetch`, nơi thực sự gọi
+  `loading.show()/.hide()`): unwrap bằng `toValue(loading)?.show()` /
+  `toValue(loading)?.hide()` thay vì gọi trực tiếp trên Ref.
+- `src/services/auth.js` (`handleRegister`): cùng root cause — `refSpinner`
+  từ `inject('spinner')` truyền thẳng vào làm `loading`, code cũ gọi
+  `loading.show()` / `loading?.hide()` trực tiếp trên Ref (không qua
+  `.value`) — sẽ throw runtime error vì Ref không có method `.show`. Đổi
+  sang `toValue(loading)?.show()` / `toValue(loading)?.hide()` cho nhất
+  quán, đúng như issue yêu cầu "tất cả nơi dùng loading".
+  `handleLogin` trong cùng file đã đúng từ trước (đã dùng `toValue`).
+
+Đã `grep -rn "loading?.show\|loading?.hide\|loading\.show(\|loading\.hide("
+src/` để tìm hết các nơi gọi trực tiếp — chỉ có 4 chỗ, cả 4 đã sửa.
+
+## Build output (npm run build) — đọc lại nguyên văn
+```
+> vue-resume-web@0.0.0 build
+> vite build
+...
+✓ built in 4.69s
+```
+Build xanh. Build-only evidence — không có test suite thật, không chạy
+`npm run dev` để click qua UI xác nhận spinner hiện/ẩn trong phiên này.
+
+## Trạng thái
+sealed_pending_verifier

--- a/agent-hub/evidence/verifier/2026-08-20-issue-9-usehelper-reactive-loading.md
+++ b/agent-hub/evidence/verifier/2026-08-20-issue-9-usehelper-reactive-loading.md
@@ -1,0 +1,29 @@
+---
+node: issue-9-usehelper-reactive-loading
+worker: verifier
+date: 2026-08-20
+verdict: SEAL
+---
+
+## Acceptance criteria checked
+1. Trace về đúng 1 node (issue-9-usehelper-reactive-loading) — OK.
+2. Diff khớp cách fix đề xuất trong
+   [issue #9](https://github.com/datvt243/vue-resume-web/issues/9):
+   `useHelper` trả Ref thay vì snapshot, các nơi gọi `.show()/.hide()` đều
+   qua `toValue()`. Tự `git diff main -- src/composables/useHelper.js
+   src/services/base.js src/services/auth.js` để đọc lại.
+3. Đã tự `grep -rn "loading?.show\|loading?.hide\|loading\.show(\|loading\.hide("
+   src/` — xác nhận không còn nơi nào gọi trực tiếp trên Ref chưa unwrap.
+   Phát hiện đúng như evidence note ghi: `auth.js` handleRegister trước đó
+   gọi `loading.show()` trực tiếp trên Ref — đây là bug runtime thật (Ref
+   không có `.show`), không phải scope creep, sửa đúng root cause chung với
+   issue #9.
+4. `npm run build` — tự chạy lại độc lập, `✓ built in Xs`, không lỗi.
+   Build-only evidence.
+5. Evidence note implementer tồn tại tại
+   `evidence/implementer/2026-08-20-issue-9-usehelper-reactive-loading.md`,
+   ghi rõ không chạy `npm run dev` để xác nhận UI — chấp nhận được vì đây
+   là bug logic thuần, đối chiếu trực tiếp qua code path.
+
+## Verdict
+SEAL.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -46,6 +46,7 @@ flowchart TD
 | `issue-4-veeform-reset-typo` | SEALED | [issue #4](https://github.com/datvt243/vue-resume-web/issues/4) — `e.nam`→`e.name`, sửa `reduce` thiếu initialValue, `errors:`→`values:`. Evidence: `evidence/implementer/2026-08-20-issue-4-veeform-reset-typo.md`, `evidence/verifier/2026-08-20-issue-4-veeform-reset-typo.md`. |
 | `issue-5-xss-vhtml-toast` | SEALED | [issue #5](https://github.com/datvt243/vue-resume-web/issues/5) — bỏ `v-html` khỏi Toasts.vue, bỏ `<br />` HTML khỏi base.js. Evidence: `evidence/implementer/2026-08-20-issue-5-xss-vhtml-toast.md`, `evidence/verifier/2026-08-20-issue-5-xss-vhtml-toast.md`. |
 | `issue-8-jwt-localstorage` | BLOCKED_ON_BACKEND | [issue #8](https://github.com/datvt243/vue-resume-web/issues/8) — cần backend set httpOnly cookie, ngoài phạm vi repo frontend. Không tạo diff giả. Issue giữ OPEN. Evidence: `evidence/implementer/2026-08-20-issue-8-jwt-localstorage-blocked.md`. |
+| `issue-9-usehelper-reactive-loading` | SEALED | [issue #9](https://github.com/datvt243/vue-resume-web/issues/9) — `useHelper` trả Ref thay vì snapshot; `base.js` + `auth.js` unwrap qua `toValue()`. Evidence: `evidence/implementer/2026-08-20-issue-9-usehelper-reactive-loading.md`, `evidence/verifier/2026-08-20-issue-9-usehelper-reactive-loading.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.

--- a/src/composables/useHelper.js
+++ b/src/composables/useHelper.js
@@ -4,14 +4,14 @@
  * Description:
  */
 
-import { inject, toValue } from 'vue'
+import { inject } from 'vue'
 
 export const useHelper = () => {
     const refSpinner = inject('spinner')
     const refToast = inject('toast')
 
     return {
-        loading: toValue(refSpinner),
+        loading: refSpinner,
         toast: refToast,
     }
 }

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -96,7 +96,7 @@ export const handleRegister = async (values, props) => {
     /**
      * spinner loading
      */
-    loading.show()
+    toValue(loading)?.show()
 
     await _axios({
         method: 'post',
@@ -129,5 +129,5 @@ export const handleRegister = async (values, props) => {
     /**
      * spinner hide
      */
-    loading?.hide()
+    toValue(loading)?.hide()
 }

--- a/src/services/base.js
+++ b/src/services/base.js
@@ -4,6 +4,7 @@
  * Description:
  */
 
+import { toValue } from 'vue'
 import { _axios } from '@/services/axios'
 import { authStore } from '@/stores/auth'
 
@@ -44,7 +45,7 @@ const handleFrameFetch = async (axiosOptions, props, callback, action) => {
     /**
      * spinner loading
      */
-    loading?.show()
+    toValue(loading)?.show()
 
     /**
      * fetch data
@@ -59,7 +60,7 @@ const handleFrameFetch = async (axiosOptions, props, callback, action) => {
     /**
      * spinner hide
      */
-    loading?.hide()
+    toValue(loading)?.hide()
 }
 
 const _helper = props => {


### PR DESCRIPTION
## Summary
- `useHelper` unwrapped the injected spinner ref with `toValue()` at setup time, so if the ref was still `null` when the composable ran, `loading` stayed `null` forever and the spinner never showed for that consumer.
- Return the ref itself from `useHelper`, unwrap at call time with `toValue()` in `base.js`'s `handleFrameFetch`.
- Also fixed `handleRegister` in `auth.js`, which called `.show()`/`.hide()` directly on the injected ref (no `.value`) — same root cause, would throw at runtime. `handleLogin` in the same file was already correct.

Closes #9

## Test plan
- [x] `npm run build` — green (build-only evidence, no test suite yet — see agent-hub/doctrine/MEMORY.md)
- [x] Evidence notes: `agent-hub/evidence/implementer/2026-08-20-issue-9-usehelper-reactive-loading.md`, `agent-hub/evidence/verifier/2026-08-20-issue-9-usehelper-reactive-loading.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)