### PR TITLE
fix: give the two VeeForm instances on PageInformation distinct keys

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-11-pageinformation-duplicate-key.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-11-pageinformation-duplicate-key.md
@@ -1,0 +1,31 @@
+---
+node: issue-11-pageinformation-duplicate-key
+worker: implementer
+date: 2026-08-20
+---
+
+## Task
+Fix [issue #11](https://github.com/datvt243/vue-resume-web/issues/11) —
+`PageInformation.vue` có 2 `<VeeForm>` khác nhau cùng `:key="'frm1'"`, Vue
+có thể reconcile Virtual DOM sai, dùng nhầm DOM node giữa 2 form.
+
+## Diff
+`src/pages/dashboard/PageInformation.vue`:
+- Form đầu (`formFields`, `handleUpdate`): `:key="'frm1'"` →
+  `:key="'frm-basic-info'"`
+- Form sau (`socialMediaFields`, `handleUpdateSocialNetwork`):
+  `:key="'frm1'"` → `:key="'frm-social-media'"`
+
+Đúng chính xác cách fix đề xuất trong issue.
+
+## Build output (npm run build) — đọc lại nguyên văn
+```
+> vue-resume-web@0.0.0 build
+> vite build
+...
+✓ built in 4.64s
+```
+Build xanh. Build-only evidence — không có test suite thật.
+
+## Trạng thái
+sealed_pending_verifier

--- a/agent-hub/evidence/verifier/2026-08-20-issue-11-pageinformation-duplicate-key.md
+++ b/agent-hub/evidence/verifier/2026-08-20-issue-11-pageinformation-duplicate-key.md
@@ -1,0 +1,20 @@
+---
+node: issue-11-pageinformation-duplicate-key
+worker: verifier
+date: 2026-08-20
+verdict: SEAL
+---
+
+## Acceptance criteria checked
+1. Trace về đúng 1 node (issue-11-pageinformation-duplicate-key) — OK.
+2. Diff nhỏ nhất, đúng khớp cách fix đề xuất trong
+   [issue #11](https://github.com/datvt243/vue-resume-web/issues/11) — 2
+   key khác nhau, mô tả rõ (`frm-basic-info`, `frm-social-media`). Tự
+   `git diff main -- src/pages/dashboard/PageInformation.vue` để đọc lại.
+3. `npm run build` — tự chạy lại độc lập, `✓ built in Xs`, không lỗi.
+   Build-only evidence.
+4. Evidence note implementer tồn tại tại
+   `evidence/implementer/2026-08-20-issue-11-pageinformation-duplicate-key.md`.
+
+## Verdict
+SEAL.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -48,6 +48,7 @@ flowchart TD
 | `issue-8-jwt-localstorage` | BLOCKED_ON_BACKEND | [issue #8](https://github.com/datvt243/vue-resume-web/issues/8) — cần backend set httpOnly cookie, ngoài phạm vi repo frontend. Không tạo diff giả. Issue giữ OPEN. Evidence: `evidence/implementer/2026-08-20-issue-8-jwt-localstorage-blocked.md`. |
 | `issue-9-usehelper-reactive-loading` | SEALED | [issue #9](https://github.com/datvt243/vue-resume-web/issues/9) — `useHelper` trả Ref thay vì snapshot; `base.js` + `auth.js` unwrap qua `toValue()`. Evidence: `evidence/implementer/2026-08-20-issue-9-usehelper-reactive-loading.md`, `evidence/verifier/2026-08-20-issue-9-usehelper-reactive-loading.md`. |
 | `issue-10-grouptags-mutate-prop` | SEALED | [issue #10](https://github.com/datvt243/vue-resume-web/issues/10) — local copy + emit thay vì mutate prop; sửa luôn tên emit `modelValue:update`→`update:modelValue` (cần thiết để v-model hoạt động). Evidence: `evidence/implementer/2026-08-20-issue-10-grouptags-mutate-prop.md`, `evidence/verifier/2026-08-20-issue-10-grouptags-mutate-prop.md`. |
+| `issue-11-pageinformation-duplicate-key` | SEALED | [issue #11](https://github.com/datvt243/vue-resume-web/issues/11) — 2 `<VeeForm>` cùng `:key="'frm1'"` → key riêng biệt. Evidence: `evidence/implementer/2026-08-20-issue-11-pageinformation-duplicate-key.md`, `evidence/verifier/2026-08-20-issue-11-pageinformation-duplicate-key.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.

--- a/src/pages/dashboard/PageInformation.vue
+++ b/src/pages/dashboard/PageInformation.vue
@@ -124,7 +124,7 @@ async function handleUpdateSocialNetwork(values) {
         </Teleport> -->
 
         <VeeForm
-            :key="'frm1'"
+            :key="'frm-basic-info'"
             :fields="formFields"
             :document="document"
             :submit-fn="handleUpdate"
@@ -135,7 +135,7 @@ async function handleUpdateSocialNetwork(values) {
     <div class="block-container">
         <Heading text="Liên kết mạng xã hội" />
         <VeeForm
-            :key="'frm1'"
+            :key="'frm-social-media'"
             :fields="socialMediaFields"
             :submit-fn="handleUpdateSocialNetwork"
             :submit-text="'Cập nhật'"


### PR DESCRIPTION
## Summary
- Both `<VeeForm>` instances on `PageInformation.vue` shared `:key="'frm1'"`, so Vue could reconcile them as the same node during diffing, risking DOM reuse across two unrelated forms.
- Gave each a distinct, descriptive key (`frm-basic-info`, `frm-social-media`).

Closes #11

## Test plan
- [x] `npm run build` — green (build-only evidence, no test suite yet — see agent-hub/doctrine/MEMORY.md)
- [x] Evidence notes: `agent-hub/evidence/implementer/2026-08-20-issue-11-pageinformation-duplicate-key.md`, `agent-hub/evidence/verifier/2026-08-20-issue-11-pageinformation-duplicate-key.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)