### PR TITLE
fix: consolidate subURL into api.config.js

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-17-suburl-dry.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-17-suburl-dry.md
@@ -1,0 +1,38 @@
+---
+node: issue-17-suburl-dry
+worker: implementer
+date: 2026-08-20
+---
+
+## Task
+Fix [issue #17](https://github.com/datvt243/vue-resume-web/issues/17) —
+`const subURL = 'api/v1/'` bị hardcode lặp lại (DRY violation). Issue đề
+xuất gộp chung với issue #6 (migrate sang env var `VITE_API_URL`), nhưng
+#6 là thay đổi kiến trúc lớn hơn nhiều, KHÔNG nằm trong phạm vi 13 issue đã
+thống nhất với operator cho phiên này. Ở đây chỉ làm đúng phần lõi DRY của
+#17: gom `subURL` về MỘT chỗ (`api.config.js`), không đổi sang env var.
+
+## Diff
+- `src/config/api.config.js`: thêm `export const subURL = 'api/v1/'`.
+- `src/services/base.js`, `src/services/auth.js`: xoá `const subURL =
+  'api/v1/'` cục bộ, import từ `@/config/api.config`.
+- `src/services/axios.js`: cũng có `const subURL = 'api/v1/'` (mới thêm
+  trong [issue #12](https://github.com/datvt243/vue-resume-web/issues/12)
+  ở phiên này) — gộp luôn vào cùng lần dọn dẹp, import từ
+  `@/config/api.config` thay vì khai báo riêng lần 3.
+
+Đã `grep -rn "const subURL" src/` — xác nhận chỉ còn đúng 1 định nghĩa ở
+`api.config.js`.
+
+## Build output (npm run build) — đọc lại nguyên văn
+```
+> vue-resume-web@0.0.0 build
+> vite build
+...
+✓ built in 4.76s
+```
+Build xanh. TS diagnostic `TOKEN` unused trong `axios.js` tiền tồn tại,
+không liên quan diff này. Build-only evidence.
+
+## Trạng thái
+sealed_pending_verifier

--- a/agent-hub/evidence/verifier/2026-08-20-issue-17-suburl-dry.md
+++ b/agent-hub/evidence/verifier/2026-08-20-issue-17-suburl-dry.md
@@ -1,0 +1,26 @@
+---
+node: issue-17-suburl-dry
+worker: verifier
+date: 2026-08-20
+verdict: SEAL
+---
+
+## Acceptance criteria checked
+1. Trace về đúng 1 node (issue-17-suburl-dry) — OK.
+2. Diff giải quyết đúng root cause của
+   [issue #17](https://github.com/datvt243/vue-resume-web/issues/17)
+   (DRY violation) mà không kéo theo scope của issue #6 (env var migration
+   — ngoài phạm vi phiên này, operator đã xác nhận chỉ làm 13 issue nhỏ).
+   Quyết định thu hẹp scope được ghi rõ lý do trong evidence note — hợp lý.
+3. Tự `grep -rn "const subURL" src/` — xác nhận chỉ còn 1 định nghĩa tại
+   `api.config.js`, cả 3 nơi dùng (`base.js`, `auth.js`, `axios.js`) đều
+   import chung. Tự `git diff main -- src/config/api.config.js
+   src/services/base.js src/services/auth.js src/services/axios.js` để
+   đọc lại.
+4. `npm run build` — tự chạy lại độc lập, `✓ built in Xs`, không lỗi mới.
+   Build-only evidence.
+5. Evidence note implementer tồn tại tại
+   `evidence/implementer/2026-08-20-issue-17-suburl-dry.md`.
+
+## Verdict
+SEAL.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -50,6 +50,7 @@ flowchart TD
 | `issue-10-grouptags-mutate-prop` | SEALED | [issue #10](https://github.com/datvt243/vue-resume-web/issues/10) — local copy + emit thay vì mutate prop; sửa luôn tên emit `modelValue:update`→`update:modelValue` (cần thiết để v-model hoạt động). Evidence: `evidence/implementer/2026-08-20-issue-10-grouptags-mutate-prop.md`, `evidence/verifier/2026-08-20-issue-10-grouptags-mutate-prop.md`. |
 | `issue-11-pageinformation-duplicate-key` | SEALED | [issue #11](https://github.com/datvt243/vue-resume-web/issues/11) — 2 `<VeeForm>` cùng `:key="'frm1'"` → key riêng biệt. Evidence: `evidence/implementer/2026-08-20-issue-11-pageinformation-duplicate-key.md`, `evidence/verifier/2026-08-20-issue-11-pageinformation-duplicate-key.md`. |
 | `issue-12-token-refresh` | SEALED | [issue #12](https://github.com/datvt243/vue-resume-web/issues/12) — lưu `tokenRefresh` + axios interceptor silent refresh khi 401. Cần backend có `POST auth/refresh` (ngoài phạm vi repo này, caveat ghi rõ). Evidence: `evidence/implementer/2026-08-20-issue-12-token-refresh.md`, `evidence/verifier/2026-08-20-issue-12-token-refresh.md`. |
+| `issue-17-suburl-dry` | SEALED | [issue #17](https://github.com/datvt243/vue-resume-web/issues/17) — `subURL` gộp về `api.config.js` (chỉ phần DRY, không làm env-var migration của issue #6). Evidence: `evidence/implementer/2026-08-20-issue-17-suburl-dry.md`, `evidence/verifier/2026-08-20-issue-17-suburl-dry.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.

--- a/src/config/api.config.js
+++ b/src/config/api.config.js
@@ -1,3 +1,4 @@
 const host = window.location.hostname
 
 export const API = host === 'localhost' ? `http://localhost:3001/` : 'https://nodejs-resume-api-ts.onrender.com/'
+export const subURL = 'api/v1/'

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -8,8 +8,7 @@ import { _axios } from '@/services/axios'
 import { authStore } from '@/stores/auth'
 import { candidateStore } from '@/stores/candidate'
 import { toValue } from 'vue'
-
-const subURL = 'api/v1/'
+import { subURL } from '@/config/api.config'
 
 export const handleLogin = async (values, props) => {
     const { email, password } = values

--- a/src/services/axios.js
+++ b/src/services/axios.js
@@ -5,11 +5,10 @@
  */
 
 import axios from 'axios'
-import { API } from '@/config/api.config'
+import { API, subURL } from '@/config/api.config'
 import { authStore } from '@/stores/auth'
 
 const TOKEN = localStorage?.getItem('token') || ''
-const subURL = 'api/v1/'
 
 const instanceAxios = axios.create({
     baseURL: API,

--- a/src/services/base.js
+++ b/src/services/base.js
@@ -7,8 +7,7 @@
 import { toValue } from 'vue'
 import { _axios } from '@/services/axios'
 import { authStore } from '@/stores/auth'
-
-const subURL = 'api/v1/'
+import { subURL } from '@/config/api.config'
 
 export const handleBase = async (axiosOptions, props, callback) => {
     /**


### PR DESCRIPTION
## Summary
- `'api/v1/'` was hardcoded separately in `auth.js`, `base.js`, and `axios.js` — bumping the API version meant hunting down every copy.
- Moved it to `api.config.js` next to the API base URL (`export const subURL`) and imported it everywhere it's used.
- Scoped to the DRY fix only. The env-var migration the issue mentions as the "real" fix (`VITE_API_URL`, tracked in issue #6) is a larger architecture change out of scope for this pass.

Closes #17

## Test plan
- [x] `npm run build` — green (build-only evidence, no test suite yet — see agent-hub/doctrine/MEMORY.md)
- [x] Evidence notes: `agent-hub/evidence/implementer/2026-08-20-issue-17-suburl-dry.md`, `agent-hub/evidence/verifier/2026-08-20-issue-17-suburl-dry.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)