### PR TITLE
chore: merge the two <style scoped> blocks in TableDefault.vue

### DIFF
--- a/agent-hub/evidence/implementer/2026-08-20-issue-19-tabledefault-merge-style.md
+++ b/agent-hub/evidence/implementer/2026-08-20-issue-19-tabledefault-merge-style.md
@@ -1,0 +1,26 @@
+---
+node: issue-19-tabledefault-merge-style
+worker: implementer
+date: 2026-08-20
+---
+
+## Task
+Fix [issue #19](https://github.com/datvt243/vue-resume-web/issues/19) —
+`TableDefault.vue` có 2 khối `<style scoped>` riêng biệt, gộp thành 1.
+
+## Diff
+`src/components/table/TableDefault.vue`: gộp `.table-responsive` và
+`.height-auto` vào chung 1 khối `<style scoped>` — đúng chính xác cách fix
+đề xuất trong issue.
+
+## Build output (npm run build) — đọc lại nguyên văn
+```
+> vue-resume-web@0.0.0 build
+> vite build
+...
+✓ built in 4.70s
+```
+Build xanh. Build-only evidence.
+
+## Trạng thái
+sealed_pending_verifier

--- a/agent-hub/evidence/verifier/2026-08-20-issue-19-tabledefault-merge-style.md
+++ b/agent-hub/evidence/verifier/2026-08-20-issue-19-tabledefault-merge-style.md
@@ -1,0 +1,20 @@
+---
+node: issue-19-tabledefault-merge-style
+worker: verifier
+date: 2026-08-20
+verdict: SEAL
+---
+
+## Acceptance criteria checked
+1. Trace về đúng 1 node (issue-19-tabledefault-merge-style) — OK.
+2. Diff nhỏ nhất, đúng cách fix đề xuất trong
+   [issue #19](https://github.com/datvt243/vue-resume-web/issues/19) — gộp
+   2 khối `<style scoped>` thành 1, giữ nguyên nội dung CSS. Tự
+   `git diff main -- src/components/table/TableDefault.vue` để đọc lại.
+3. `npm run build` — tự chạy lại độc lập, `✓ built in Xs`, không lỗi.
+   Build-only evidence.
+4. Evidence note implementer tồn tại tại
+   `evidence/implementer/2026-08-20-issue-19-tabledefault-merge-style.md`.
+
+## Verdict
+SEAL.

--- a/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
+++ b/agent-hub/haven/diagrams/dev-loop.prime-mermaid.md
@@ -52,6 +52,7 @@ flowchart TD
 | `issue-12-token-refresh` | SEALED | [issue #12](https://github.com/datvt243/vue-resume-web/issues/12) — lưu `tokenRefresh` + axios interceptor silent refresh khi 401. Cần backend có `POST auth/refresh` (ngoài phạm vi repo này, caveat ghi rõ). Evidence: `evidence/implementer/2026-08-20-issue-12-token-refresh.md`, `evidence/verifier/2026-08-20-issue-12-token-refresh.md`. |
 | `issue-17-suburl-dry` | SEALED | [issue #17](https://github.com/datvt243/vue-resume-web/issues/17) — `subURL` gộp về `api.config.js` (chỉ phần DRY, không làm env-var migration của issue #6). Evidence: `evidence/implementer/2026-08-20-issue-17-suburl-dry.md`, `evidence/verifier/2026-08-20-issue-17-suburl-dry.md`. |
 | `issue-18-dead-code` | SEALED | [issue #18](https://github.com/datvt243/vue-resume-web/issues/18) — xóa `handleBaseDelete`, `_part`, `components/navbar/*.js`, unused `ref`/`TOKEN`. Không bật ESLint rule (không verify được). Evidence: `evidence/implementer/2026-08-20-issue-18-dead-code.md`, `evidence/verifier/2026-08-20-issue-18-dead-code.md`. |
+| `issue-19-tabledefault-merge-style` | SEALED | [issue #19](https://github.com/datvt243/vue-resume-web/issues/19) — gộp 2 khối `<style scoped>` trong TableDefault.vue thành 1. Evidence: `evidence/implementer/2026-08-20-issue-19-tabledefault-merge-style.md`, `evidence/verifier/2026-08-20-issue-19-tabledefault-merge-style.md`. |
 
 Any regression phải là **node mới** (LAI-13) — không được sửa trực tiếp PM
 status của node cũ để "gỡ" một SEAL đã có.

--- a/src/components/table/TableDefault.vue
+++ b/src/components/table/TableDefault.vue
@@ -135,9 +135,7 @@ const renderCellContent = defineComponent({
 .table-responsive {
     min-height: 300px;
 }
-</style>
 
-<style scoped>
 .height-auto {
     height: auto !important;
     min-height: auto !important;


### PR DESCRIPTION
## Summary
- `TableDefault.vue` had two separate `<style scoped>` blocks with no reason to be split — reads as two style scopes when it's really one.
- Merged into a single block, content unchanged.

Closes #19

## Test plan
- [x] `npm run build` — green (build-only evidence, no test suite yet — see agent-hub/doctrine/MEMORY.md)
- [x] Evidence notes: `agent-hub/evidence/implementer/2026-08-20-issue-19-tabledefault-merge-style.md`, `agent-hub/evidence/verifier/2026-08-20-issue-19-tabledefault-merge-style.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)