### PR TITLE
chore(agent-hub): add boot-reuse guards to implementer/verifier recipes

### DIFF
--- a/agent-hub/haven/workers/implementer/recipes/pick_next.md
+++ b/agent-hub/haven/workers/implementer/recipes/pick_next.md
@@ -3,9 +3,21 @@
 - Output: `{node, diagram, current_state, acceptance: string[],
   files: string[], blocked_by: string|null}`
 
+> [GUARD, added 2026-08-31] If `/boot` already ran in THIS SAME session,
+> `NORTHSTAR.md` / `doctrine/MEMORY.md` / `doctrine/domains/PROJECT.md` /
+> `haven/diagrams/` are already in context from that pass — steps 1-2 below
+> REUSE that content, don't `Read` it again (a second full read of the same
+> 4 files is pure duplication, same class of token waste as the
+> `agent-hub/CLAUDE.md` case already fixed in `boot/SKILL.md`). Only `Read`
+> for real when: (a) `/worker implementer` is invoked without a prior
+> `/boot` this session, or (b) the content might have changed since it was
+> last read.
+
 ## Steps
-1. Read `NORTHSTAR.md` + `doctrine/MEMORY.md` + `doctrine/domains/PROJECT.md`.
-2. Read EVERY diagram in `haven/diagrams/`, list nodes + PM status.
+1. Get `NORTHSTAR.md` + `doctrine/MEMORY.md` + `doctrine/domains/PROJECT.md`
+   — reuse from `/boot` if available (see GUARD above), else `Read` fresh.
+2. Get every diagram in `haven/diagrams/`, list nodes + PM status — reuse
+   from `/boot` if available (see GUARD above), else `Read` fresh.
 3. If the task doesn't match an existing node, don't invent work —
    append a new row to the PM status table for it (`IN_PROGRESS`) instead
    of blocking, matching how prior ad-hoc/operator-direct tasks were

--- a/agent-hub/haven/workers/verifier/recipes/verify_seal.md
+++ b/agent-hub/haven/workers/verifier/recipes/verify_seal.md
@@ -13,7 +13,12 @@
 2. Read the NOTE — only the note, do NOT open the diff directly.
    (`EvidenceOnly`)
 3. Read the NODE — get acceptance criteria from `haven/diagrams/`,
-   forbidden states from `CLAUDE.md`.
+   forbidden states from `CLAUDE.md`. [GUARD, added 2026-08-31] Don't `Read
+   agent-hub/CLAUDE.md` yourself for this — same mechanism as
+   `boot/SKILL.md`: the harness auto-injects this file's full content as a
+   nested-CLAUDE.md `<system-reminder>` the moment step 2 touches anything
+   under `agent-hub/`; reading it again here duplicates that content. Read
+   it directly only if it's actually missing from context after step 2.
 4. Check the command in the note matches `doctrine/MEMORY.md` (e.g. `npm
    run build` from repo root — this project has NO test command, don't
    REOPEN just because "tests pass" is missing when the note already


### PR DESCRIPTION
Same fix already merged in the sibling backend repo (PR #95).

- `implementer/recipes/pick_next.md`: guard steps 1-2 so a session that already ran `/boot` reuses `NORTHSTAR.md` / `doctrine/MEMORY.md` / `doctrine/domains/PROJECT.md` / `haven/diagrams/` instead of Read-ing them again.
- `verifier/recipes/verify_seal.md`: guard step 3 so `CLAUDE.md` forbidden states aren't re-Read when the harness already auto-injected the file during step 2.

Docs/recipe-only change under `agent-hub/`, no application code touched.