### PR TITLE
chore(agent-hub): tighten verifier re-run scope, drop stale NORTHSTAR read

### DIFF
--- a/agent-hub/haven/workers/verifier/manifest.yaml
+++ b/agent-hub/haven/workers/verifier/manifest.yaml
@@ -13,5 +13,7 @@ hard_rules:
   - NeverVerifyOwnWork   # can't grade a diff it wrote itself
   - RatchetOnly          # PM status only ever advances, never regresses
   - NoMainEdit           # REOPEN if the evidence note doesn't name a dedicated (non-main) branch used to create the diff
-reads: [evidence/implementer/, haven/diagrams/, NORTHSTAR.md, CLAUDE.md]
+reads: [evidence/implementer/, haven/diagrams/, doctrine/MEMORY.md, CLAUDE.md]
+# doctrine/MEMORY.md: recipe step 4 needs it to check the note's command.
+# No NORTHSTAR.md — recipe never uses it, was dead weight on every spawn.
 writes: [evidence/verifier/]   # and PM status on the diagram

--- a/agent-hub/haven/workers/verifier/recipes/verify_seal.md
+++ b/agent-hub/haven/workers/verifier/recipes/verify_seal.md
@@ -8,6 +8,30 @@
   immediately: "I wrote this, a separate verifier pass is required."
   (`NeverVerifyOwnWork`)
 
+## Re-run scope [cost-driven, added 2026-09-02]
+Default: AUDIT the note, don't re-run `npm run build`/dev-server checks from
+scratch. `EvidenceOnly` means "don't substitute reasoning for real
+evidence" — it does NOT mean "always regenerate the evidence yourself." If
+the note's output is verbatim, not truncated (step 5), the command matches
+`doctrine/MEMORY.md` (step 4), and it covers every acceptance criterion
+(step 6) → verdict straight off the note, no re-run.
+
+Only re-run (partial or full) when:
+- The note is missing a citation, output looks truncated/hidden, or the
+  command doesn't match doctrine → REOPEN per steps 4-5 instead — don't
+  spend effort re-running a note that's already broken.
+- The node is outward-facing or a `/release` gate — higher risk than an
+  ordinary diff, worth the independent-confirmation cost.
+- `doctrine/domains/PROJECT.md` names this class of change as needing
+  independent re-run (a per-project call, not the kit default).
+
+Observed in practice (usage audit 2026-09-02, across 3 production hubs):
+verifiers re-running the FULL build from scratch for every node — even a
+1-line doc fix — doubled (up to 6x with parallel subagents) the token cost
+of every change with no change to the SEAL/REOPEN verdict. Not a bug, but
+not what `EvidenceOnly` asks for either — this section pins the boundary so
+it's not reinvented per hub.
+
 ## Steps
 1. REFUSE SELF-GRADING FIRST — did I write this diff in this session?
 2. Read the NOTE — only the note, do NOT open the diff directly.


### PR DESCRIPTION
Synced from `agent-hub-init` kit (usage audit 2026-09-02).

## What
- `haven/workers/verifier/manifest.yaml`: `reads:` drops unused `NORTHSTAR.md`, adds `doctrine/MEMORY.md` (actually needed by recipe step 4, was undeclared).
- `haven/workers/verifier/recipes/verify_seal.md`: adds a "Re-run scope" section — verifier now audits the implementer's evidence note by default instead of independently re-running build/test from scratch on every node.

## Why
Usage audit across 3 production hubs (this one included) found verifiers re-running full build/lint/test from cold cache for every node — even 1-line doc changes — doubling (in some cases 6x with parallel subagents) the token cost of every change with no change to the SEAL/REOPEN verdict. `EvidenceOnly` means "don't substitute reasoning for evidence," not "always regenerate the evidence yourself." This PR pins that boundary explicitly so it's not reinvented per hub.

Re-run is still expected for: suspicious/truncated notes, outward-facing or `/release`-gate nodes, or anything `doctrine/domains/PROJECT.md` explicitly flags.

Bookkeeping-only change under `agent-hub/` — no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)