### PR TITLE
chore(agent-hub): sync worker-runs.log tracking + /browser-debugger

### DIFF
--- a/.claude/commands/browser-debugger.md
+++ b/.claude/commands/browser-debugger.md
@@ -1,0 +1,69 @@
+---
+description: "Open a browser (Chrome/Firefox/Edge) with remote-debugging port 9888 so Claude can inspect/control it — optionally starting `npm run dev` first and pointing the browser at it. Usage: /browser-debugger [--browser=chrome|firefox|edge] [--run-dev]. Read-only dev utility, no code changes, no seal gate."
+argument-hint: "[--browser=chrome|firefox|edge] [--run-dev]"
+---
+
+# /browser-debugger — open a browser with CDP debugging on port 9888
+
+Local dev-environment utility only — never touches project source code,
+never commits/pushes/deploys. `gate: none`, same class as `/hub-tokens`: no
+seal gate, no evidence note, no worker identity needed.
+
+## Steps
+1. **Parse args.** `--browser=<name>` — one of `chrome`/`chromium`,
+   `firefox`, `edge` (case-insensitive), default `chrome` if omitted or
+   malformed — don't fail on a typo'd value, just tell the operator you
+   fell back to the default. `--run-dev` — boolean flag, no value.
+2. **If `--run-dev` was passed:**
+   a. Check `package.json` at the repo root for a `scripts.dev` entry. Not
+      present → skip starting anything, note "no `dev` script in
+      package.json" in the final report, fall through to step 3 with the
+      default target URL (`http://localhost:3000`).
+   b. Present → detect the package manager from the lockfile
+      (`package-lock.json` → `npm`, `yarn.lock` → `yarn`,
+      `pnpm-lock.yaml` → `pnpm`; default `npm` if none found), then start
+      `<pm> run dev` in the background (`run_in_background: true`),
+      capture its output.
+   c. Poll the dev server's own output for a local URL (common patterns:
+      "Local:", "http://localhost:", "ready on") for up to ~15s. Found →
+      use that URL as the target. Not found in time → fall back to
+      `http://localhost:3000`, note in the report that the URL was
+      guessed, not read from actual output.
+3. **Resolve the browser executable** for `--browser` + the current OS
+   (macOS/Linux/Windows) — real installed paths, don't assume:
+   - macOS: `/Applications/Google Chrome.app/...`,
+     `/Applications/Firefox.app/...`,
+     `/Applications/Microsoft Edge.app/...`.
+   - Linux: `google-chrome`/`chromium`, `firefox`, `microsoft-edge` on
+     `$PATH`.
+   - Windows (git-bash/WSL interop): standard `Program Files` install
+     paths for each.
+   Not found → report the real error (which path/command was tried) and
+   stop — don't silently fall back to a different browser than requested.
+4. **Launch** with remote debugging on port **9888**
+   (`--remote-debugging-port=9888` for Chrome/Edge/Chromium;
+   `--start-debugger-server 9888` for Firefox), pointed at the URL from
+   step 2, as a background process. Capture the PID.
+5. **Verify the debug port is actually responding** —
+   `curl -fsS http://localhost:9888/json/version` (or equivalent), read
+   the output back. Fails → report the real error, don't claim success.
+6. **Report — confirm message, exactly these lines:**
+   ```
+   🌐 Browser: <chrome|firefox|edge> (PID <pid>)
+   🔗 Debug port: localhost:9888 — <responding | not responding: reason>
+   📍 URL: <url opened>
+   🚀 Dev server: <started via <pm> run dev | already running | no dev script found | skipped (--run-dev not passed)>
+   ```
+
+## Failure branches
+| Failure | Handling |
+|---|---|
+| Requested browser not installed / path not found | Report the exact path/command tried, stop — don't silently substitute another browser |
+| Port 9888 already in use | Report it (`lsof -i :9888` output), ask whether to reuse the existing instance or stop — don't kill another process unasked |
+| `--run-dev` passed but no `dev` script in `package.json` | Note it in the report, open the browser at the default URL instead of failing the whole command |
+| Dev server starts but never prints a detectable local URL | Fall back to `http://localhost:3000`, say so plainly in the report — don't guess a wrong port silently |
+
+## Runtime
+`/browser-debugger [--browser=chrome|firefox|edge] [--run-dev]`. Purely
+local: no git, no network call other than the local CDP check, no
+project-file edits. Safe to re-run.

--- a/.claude/skills/hub-tokens/SKILL.md
+++ b/.claude/skills/hub-tokens/SKILL.md
@@ -54,10 +54,12 @@ echo "pick_next/verify_seal — large size here is not a recurring cost):"
 ARCHIVE_B=$(find "$HUB/haven/diagrams" -type f -iname "*archive*" 2>/dev/null -exec cat {} + 2>/dev/null | wc -c | tr -d ' ')
 EVI_I_B=$(bytes_glob "$HUB/evidence/implementer")
 EVI_V_B=$(bytes_glob "$HUB/evidence/verifier")
+TODO_LOG_B=$(wc -c < "$HUB/evidence/worker-runs.log" 2>/dev/null | tr -d ' '); TODO_LOG_B=${TODO_LOG_B:-0}
 row "haven/diagrams/*archive*" "$ARCHIVE_B"
 row "evidence/implementer/" "$EVI_I_B"
 row "evidence/verifier/" "$EVI_V_B"
-COLD_B=$(( ARCHIVE_B + EVI_I_B + EVI_V_B ))
+row "evidence/worker-runs.log" "$TODO_LOG_B"
+COLD_B=$(( ARCHIVE_B + EVI_I_B + EVI_V_B + TODO_LOG_B ))
 row "= cold storage total" "$COLD_B"
 echo
 TOTAL_B=$(( SESSION_B + COLD_B ))

--- a/agent-hub/evidence/README.md
+++ b/agent-hub/evidence/README.md
@@ -5,6 +5,7 @@
 ```
 evidence/implementer/<date>-<slug>.md
 evidence/verifier/<date>-<slug>-{seal|reopen}.md
+evidence/worker-runs.log
 ```
 Date as `YYYY-mm-dd`, slug kebab-case derived from the task name. Flat
 files — no nested `<date>/` subfolder (this is the convention actually
@@ -14,6 +15,9 @@ otherwise).
 ## Format — implementer note
 - Title (date - node) · Worker · Version · Node (points to the diagram) ·
   Task (verbatim prompt)
+- `## Hub bytes before` — [added 2026-09-02] byte count measured at
+  `pick_next` step 7, before the diff starts — the verifier reads this
+  back when writing `worker-runs.log`, don't skip it
 - `## Branch` — the dedicated branch checked out from `main` before
   changing any file (required — see `CLAUDE.md` → Branching rule; missing
   this line = verifier REOPEN with `MAIN_EDIT`)
@@ -34,6 +38,31 @@ otherwise).
 - Worker · Node · New PM status (PENDING/SEALED/REOPEN)
 - `## Reasoning` — cite evidence for each criterion
 - `## Missing` — only present on REOPEN
+- `## Re-run` — [added 2026-09-02] `none`/`partial`/`full`, declared
+  honestly per what was actually done (see "Re-run scope" in
+  `recipes/verify_seal.md`), with a reason if not `none`. The verifier
+  reads this back when writing `worker-runs.log` — not decorative.
+
+## Format — worker-runs.log
+- [added 2026-09-02] NOT a narrative note like the ones above — an
+  **append-only file, 1 line per implementer or verifier pass that ends**.
+  Written by `pick_next.md`/`implement.md`/`verify_seal.md` themselves.
+- Two line shapes:
+  - Implementer (only on `blocked`/`failed`, never reaching the verifier):
+    `<ISO timestamp> role=implementer outcome=blocked|failed node=<slug>
+    hub_bytes_before=<N> verifier_rerun=n/a`
+  - Verifier (every verdict — SEAL or REOPEN):
+    `<ISO timestamp> role=verifier outcome=SEAL|REOPEN node=<slug>
+    rerun=none|partial|full hub_bytes_before=<N> hub_bytes_after=<N>`
+  `hub_bytes_*` use this hub's own `/hub-tokens` "per-session total"
+  formula.
+- One line per round-trip, not one per node's whole lifetime — a node
+  REOPENed 3 times has 3 verifier lines sharing the same `node=`.
+- **Purpose**: real, non-inferred data to spot patterns later — repeated
+  REOPEN, a verifier re-running despite the audit-only default, an
+  unusual jump in hub size between two runs. Not a real token count.
+- Cold storage — not re-read wholesale every worker session, only opened
+  when someone audits patterns on purpose. NEVER delete a line.
 
 ## The three rules of this directory
 1. **VERBATIM, ALWAYS** — never claim something without a real citable

--- a/agent-hub/haven/workers/implementer/recipes/implement.md
+++ b/agent-hub/haven/workers/implementer/recipes/implement.md
@@ -39,6 +39,14 @@
    done" in the evidence note — don't fix it inline.
 10. Write to `evidence/` following the format in `evidence/README.md` —
     MUST include the branch name used in step 0.
+11. [added 2026-09-02] ONLY when the result is `blocked` or `failed`
+    (never reaches the verifier) — append one line to
+    `evidence/worker-runs.log` (create the file if missing):
+    `role=implementer outcome=blocked|failed node=<slug>
+    hub_bytes_before=<N from pick_next step 7> verifier_rerun=n/a`. When
+    the result is `sealed_pending_verifier`, do NOT log here — the
+    verifier logs both sides (before/after) in `verify_seal.md` once it
+    has a real verdict.
 
 ## Hard rules honored
 `SmallestDiff` | `TestsBeforeDone` | `EvidencePerAction` | `NoSilentFailure` |

--- a/agent-hub/haven/workers/implementer/recipes/pick_next.md
+++ b/agent-hub/haven/workers/implementer/recipes/pick_next.md
@@ -28,9 +28,15 @@
    invented (e.g. `src/models/`, `src/composables/`, `src/services/`).
 6. Declare blockers: if `doctrine/MEMORY.md` is missing a needed command,
    stop and report `blocked` — do NOT guess a command.
-7. Evidence: write `evidence/implementer/<date>-<slug>.md` (flat file,
+7. [added 2026-09-02] Measure `hub_bytes_before` — the total bytes across
+   the 5 categories `/hub-tokens` calls the "per-session total" (root
+   files, `doctrine/`, the active `haven/diagrams/`, 2 worker bundles).
+   Record this number in the evidence note at step 8 — the verifier reads
+   it back to compute the hub-size diff in `worker-runs.log`.
+8. Evidence: write `evidence/implementer/<date>-<slug>.md` (flat file,
    matches the convention actually used across every prior evidence note
-   — see `evidence/README.md`).
+   — see `evidence/README.md`), including the line
+   `## Hub bytes before: <N>` from step 7.
 
 ## Hard rules honored
 `NodeBeforeCode` | `EvidencePerAction` | `NoSilentFailure`

--- a/agent-hub/haven/workers/verifier/recipes/verify_seal.md
+++ b/agent-hub/haven/workers/verifier/recipes/verify_seal.md
@@ -66,6 +66,25 @@ it's not reinvented per hub.
 12. Write the verdict to
     `evidence/verifier/<date>-<slug>-{seal|reopen}.md` (flat file,
     matches the convention used across every prior evidence note).
+12b. [added 2026-09-02] In the verdict note, truthfully declare 1 line
+   `## Re-run`: `none` (audit-only, the correct default per "Re-run
+   scope" above), `partial` (name exactly which command was re-run), or
+   `full` (re-ran the entire build from scratch) — always with a reason
+   matching one of the 3 exception cases in "Re-run scope" if not `none`.
+   Misdeclaring this corrupts the duplicate-cost signal step 13 depends
+   on.
+13. [added 2026-09-02] Append 1 line to `evidence/worker-runs.log`
+   (create the file if it doesn't exist): take `hub_bytes_before` from the
+   `## Hub bytes before` line in the implementer's note (already read in
+   step 2, reuse it); measure `hub_bytes_after` the same way (this hub's
+   `/hub-tokens` per-session total), taken AFTER updating PM status in
+   step 11 if SEALed. Format:
+   ```
+   <ISO timestamp> role=verifier outcome=SEAL|REOPEN node=<slug>
+   rerun=none|partial|full hub_bytes_before=<N> hub_bytes_after=<N>
+   ```
+   NEVER edit/delete an old line here — append-only, same rule as the
+   rest of `evidence/`.
 
 ## Hard rules honored
 `NeverVerifyOwnWork` | `EvidenceOnly` | `VerdictOnly` | `RatchetOnly` | `NoMainEdit`


### PR DESCRIPTION
Sync from agent-hub-init kit (/sys), docs/commands only — no src/ change.

- Patches the 2026-09-02 kit feature (hub_bytes_before/after + worker-runs.log logging) into pick_next.md / implement.md / verify_seal.md / evidence/README.md / hub-tokens/SKILL.md — this hub didn't have it yet.
- Adds .claude/commands/browser-debugger.md (spec existed in the kit, wasn't generated here).

npm run build: clean, 5.51s.

Not touched, flagged for a separate decision:
- dev-loop.prime-mermaid.md is 53917B, ~3.5x over the 15KB /hub-tokens threshold — archive pass overdue, left to the operator (PROTECTED file).
- kit's generic /release custom-command spec NOT installed — this repo's real .claude/skills/release/SKILL.md is already a staging->main gate with real branch-protection checks; installing the generic one would collide under the same /release name.