### PR TITLE
chore(agent-hub): batch verifier mode + persona-load skill

### DIFF
--- a/.claude/skills/boot/SKILL.md
+++ b/.claude/skills/boot/SKILL.md
@@ -21,8 +21,11 @@ during this step — read and report only.
 4. Read `agent-hub/doctrine/domains/PROJECT.md` — especially the Traps
    table, don't repeat a known bug (e.g. `createMemoryHistory`, GET login
    leaking the password).
-5. Read every file in `agent-hub/haven/diagrams/` — list nodes + current PM
-   status.
+5. Read every file in `agent-hub/haven/diagrams/` EXCEPT any file whose
+   name contains `archive` (`dev-loop-archive.md`...) — [fixed 2026-09-06]
+   that's cold storage by design (currently ~98KB — reading it here every
+   session was defeating the entire point of archiving). List nodes +
+   current PM status from the non-archive file(s) only.
 6. Read `agent-hub/haven/workers/` — confirm there are exactly 2 workers:
    implementer, verifier.
 7. Read at most the 5 most recent evidence notes (newest file by date) in

--- a/.claude/skills/persona-load/SKILL.md
+++ b/.claude/skills/persona-load/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: persona-load
+description: "Load an on-demand expert-persona or a named panel from this project's own persona library (outside agent-hub/), printing the loader's SEALED output for the current worker session to read. Advisory only, read-only, no side effects."
+argument-hint: "<category>/<name> | -p <panel> | -l [category]"
+---
+
+# /persona-load — load an expert persona or panel on demand
+
+Read-only. Wraps this project's own `scripts/load_persona.sh` (lives in
+the code repo, NOT in `agent-hub/` — a persona loader is code, and
+`CODE_IN_HAVEN` forbids code inside `haven/`). Prints one persona or a
+whole panel so the current implementer/verifier pass can borrow that
+expert's judgment on a domain-specific question — advisory only, never a
+substitute for real evidence.
+
+## Why this exists
+A persona is a high-precision pointer into the model's latent space:
+naming a real expert activates a cluster of domain knowledge that would
+otherwise take paragraphs to restate. Loading ALL personas up front gives
+zero lift and wastes tokens (empirically, per the persona-system brief
+this skill implements) — this command is the on-demand hook so a worker
+only pays for the 1 persona (or panel of 2-4) actually relevant to the
+task at hand.
+
+## Steps
+1. **Locate the loader.** Check `scripts/load_persona.sh` exists at the
+   project root (or whatever `<<root>>` this project declared in
+   `doctrine/domains/PROJECT.md`, if it did). If it doesn't exist, stop
+   and report: "persona system not set up in this project — build it
+   first via `/worker implementer` using the persona-system brief, then
+   retry" — never fabricate a persona inline as a fallback.
+2. **Parse `$ARGUMENTS`**:
+   - `<category>/<name>` → load that one persona file.
+   - `-p <panel>` → load every member of that named panel (2-4 files).
+   - `-l [category]` → list available personas (all, or filtered to one
+     category) instead of loading content — for browsing.
+   - No/invalid arguments → run `scripts/load_persona.sh -h` and print
+     its usage output verbatim, don't invent your own usage text.
+3. **Run the loader for real** (`scripts/load_persona.sh <args>`), READ
+   BACK its stdout verbatim — this includes the `=== SEAL ===` header +
+   sha256 the script itself prints. Never paraphrase a persona's content
+   into your own summary; print what the script actually returned.
+4. **Use the result as a lens, not a ruling.** Whatever the loaded
+   persona/panel says informs the current implementer's or verifier's
+   judgment on a domain-specific question. It NEVER overrides a hard rule
+   (`TestsBeforeDone`, `EvidencePerAction`, `NeverVerifyOwnWork`, the 5
+   forbidden states, this project's own `doctrine/`) and never counts as
+   evidence by itself — a verifier still needs a real cited test/output
+   to SEAL; "persona X approved this" is not an acceptance criterion.
+
+## Hard rules honored
+- `PersonaAsLensNotAuthority` — a persona/panel informs judgment, never
+  grants capability, never overrides `doctrine/`/the 5 forbidden
+  states/a safety file, never substitutes for real evidence. Layering:
+  `<<project's safety file>> > agent-hub doctrine > repo conventions >
+  persona`.
+- `CodeStaysOutOfHaven` — the loader script and persona library live in
+  the project's own code tree, never inside `agent-hub/haven/` or
+  `agent-hub/doctrine/` (would trip `CODE_IN_HAVEN`, and would silently
+  inflate the recurring per-session token cost `/hub-tokens` tracks).
+- `ReadBackBeforeClaim` — always print the loader's real stdout, never a
+  paraphrase of what a persona file "probably says".
+
+## Failure branches
+| Failure | Handling |
+|---|---|
+| `scripts/load_persona.sh` missing | Report "not set up yet", point at building it via `/worker implementer`, stop — don't invent persona content inline |
+| Requested `<category>/<name>` or panel not found | Let the loader's own "fail loudly with a suggestion" behavior surface — print its real stderr, don't guess a substitute persona |
+| Loader script errors out (bad permissions, syntax) | Report the real error verbatim, don't retry with `sudo`/`chmod` or work around it silently |
+
+## Runtime
+`/persona-load <category>/<name>` — load one persona.
+`/persona-load -p <panel>` — load a whole panel.
+`/persona-load -l [category]` — list available personas.
+Requires the project to already have its persona system built (loader +
+library in its own code tree — see `doctrine/domains/PROJECT.md` for this
+project's `<<root>>`/safety-file names if declared there). Building that
+system the first time is a normal code change — run it through
+`/worker implementer "build the on-demand expert-persona system"` like
+any other task, not through this command.

--- a/.claude/skills/worker/SKILL.md
+++ b/.claude/skills/worker/SKILL.md
@@ -7,7 +7,13 @@ description: "Become an agent-hub worker (implementer or verifier) and run its r
 
 `args` holds `<wid> "<task>"` — `wid` is `implementer` or `verifier`, the
 rest (quoted or not) is the task. If `wid` or `task` is missing, stop and
-ask — don't guess.
+ask — don't guess. [added 2026-09-06] For `verifier` specifically, the
+rest can also be multiple evidence note paths (batch) or the keyword
+`all-pending` (every node currently `sealed_pending_verifier` on the
+active diagram) — see "Batch verify" in `recipes/verify_seal.md`. Batch
+only amortizes the one-time subagent-spawn/context-load cost across N
+nodes; each node still gets its own independent verdict from its own
+evidence.
 
 ## Load bundle (mandatory before anything else)
 Read in this exact order:

--- a/agent-hub/.gitattributes
+++ b/agent-hub/.gitattributes
@@ -1,0 +1,1 @@
+haven/diagrams/*.prime-mermaid.md merge=union

--- a/agent-hub/haven/workers/implementer/manifest.yaml
+++ b/agent-hub/haven/workers/implementer/manifest.yaml
@@ -15,5 +15,9 @@ hard_rules:
   - TestsBeforeDone     # must run a real npm run build before reporting done (no test suite — see doctrine/MEMORY.md)
   - NodeBeforeCode      # must have a node on the diagram before writing code
   - BranchBeforeCode    # must checkout a dedicated branch from main before changing any file — never edit/commit on main → MAIN_EDIT
+  - AppendOnly          # [added 2026-09-06] new node rows always appended at
+                         # the end of the PM status table, never inserted mid-
+                         # table — required for agent-hub/.gitattributes'
+                         # merge=union to merge cleanly across branches
 reads: [NORTHSTAR.md, doctrine/MEMORY.md, doctrine/domains/, haven/diagrams/]
 writes: [evidence/implementer/]

--- a/agent-hub/haven/workers/implementer/recipes/pick_next.md
+++ b/agent-hub/haven/workers/implementer/recipes/pick_next.md
@@ -18,10 +18,16 @@
    — reuse from `/boot` if available (see GUARD above), else `Read` fresh.
 2. Get every diagram in `haven/diagrams/`, list nodes + PM status — reuse
    from `/boot` if available (see GUARD above), else `Read` fresh.
+   [clarified 2026-09-06] "every diagram" means every file WITHOUT
+   `archive` in its name, matching `/boot` step 5's rule exactly.
 3. If the task doesn't match an existing node, don't invent work —
    append a new row to the PM status table for it (`IN_PROGRESS`) instead
    of blocking, matching how prior ad-hoc/operator-direct tasks were
-   added (e.g. `eslint-lint-actually-runs`).
+   added (e.g. `eslint-lint-actually-runs`). [added 2026-09-06] Always at
+   the END of the table, never inserted mid-table (`AppendOnly`) —
+   required for `agent-hub/.gitattributes`' `merge=union` to merge
+   cleanly when 2 branches each add a different new node around the same
+   time.
 4. If genuinely ambiguous (task unclear, not just "no existing node") —
    stop and ask, don't guess.
 5. Locate code anchors by grepping `../src/` — real paths only, never
@@ -39,7 +45,7 @@
    `## Hub bytes before: <N>` from step 7.
 
 ## Hard rules honored
-`NodeBeforeCode` | `EvidencePerAction` | `NoSilentFailure`
+`NodeBeforeCode` | `EvidencePerAction` | `NoSilentFailure` | `AppendOnly`
 
 ## Failure branches
 | Failure | Handling |

--- a/agent-hub/haven/workers/verifier/manifest.yaml
+++ b/agent-hub/haven/workers/verifier/manifest.yaml
@@ -13,6 +13,9 @@ hard_rules:
   - NeverVerifyOwnWork   # can't grade a diff it wrote itself
   - RatchetOnly          # PM status only ever advances, never regresses
   - NoMainEdit           # REOPEN if the evidence note doesn't name a dedicated (non-main) branch used to create the diff
+  - AppendOnly          # [added 2026-09-06] update a node's own row IN PLACE
+                         # on SEAL — never reorder/move rows in the PM status
+                         # table, same reason as the implementer's AppendOnly
 reads: [evidence/implementer/, haven/diagrams/, doctrine/MEMORY.md, CLAUDE.md]
 # doctrine/MEMORY.md: recipe step 4 needs it to check the note's command.
 # No NORTHSTAR.md — recipe never uses it, was dead weight on every spawn.

--- a/agent-hub/haven/workers/verifier/recipes/verify_seal.md
+++ b/agent-hub/haven/workers/verifier/recipes/verify_seal.md
@@ -1,12 +1,35 @@
 > the gate.
 
 # Contract
-- Input: path to an evidence note under `evidence/implementer/`.
-- Output: `{verdict: SEAL|REOPEN, node, cited: string[], missing: string[],
-  forbidden_hit: string|null, pm_updated: boolean}`
+- Input: path to an evidence note under `evidence/implementer/`, OR
+  multiple paths (batch), OR `all-pending` (every node currently
+  `sealed_pending_verifier` on the active diagram — see "Batch verify"
+  below). [batch added 2026-09-06]
+- Output: AN ARRAY, 1 element per node: `{verdict: SEAL|REOPEN, node,
+  cited: string[], missing: string[], forbidden_hit: string|null,
+  pm_updated: boolean, rerun: none|partial|full}`.
 - REFUSAL: if this same session wrote the diff under review → refuse
   immediately: "I wrote this, a separate verifier pass is required."
-  (`NeverVerifyOwnWork`)
+  (`NeverVerifyOwnWork`) — in a batch, this applies PER NODE: refuse just
+  the self-written node, don't cancel the rest of the batch.
+
+## Batch verify [added 2026-09-06]
+The heaviest cost of a verify pass isn't the act of verifying — it's
+reloading the whole bundle + doctrine on every subagent spawn (this hub's
+diagram alone is ~21KB active + ~98KB archived). Batch verify pays that
+cost EXACTLY ONCE for N nodes instead of N times, without changing
+anything about the substance of verifying:
+- Step 1 (self-refusal check) runs ONCE for the whole batch.
+- Steps 2-12b (read note, check criteria, scan forbidden states + branch
+  check, verdict, write verdict, Re-run declaration) run REPEATEDLY,
+  INDEPENDENTLY, for EACH node — using node A's evidence/reasoning to
+  infer node B's verdict is forbidden, even if the two notes look
+  similar. Each node still gets its own evidence, own verdict, own
+  verdict note.
+- Being in a batch is NEVER an excuse to loosen any criterion in steps
+  2-12b — batching only folds the SPAWN COST, never the VERDICT.
+- `all-pending`: first list every `sealed_pending_verifier` node on
+  `dev-loop.prime-mermaid.md`, then run the full procedure below on each.
 
 ## Re-run scope [cost-driven, added 2026-09-02]
 Default: AUDIT the note, don't re-run `npm run build`/dev-server checks from
@@ -34,8 +57,8 @@ it's not reinvented per hub.
 
 ## Steps
 1. REFUSE SELF-GRADING FIRST — did I write this diff in this session?
-2. Read the NOTE — only the note, do NOT open the diff directly.
-   (`EvidenceOnly`)
+2. [LOOP STARTS HERE FOR EACH NODE if batch] Read the NOTE — only the
+   note, do NOT open the diff directly. (`EvidenceOnly`)
 3. Read the NODE — get acceptance criteria from `haven/diagrams/`,
    forbidden states from `CLAUDE.md`. [GUARD, added 2026-08-31] Don't `Read
    agent-hub/CLAUDE.md` yourself for this — same mechanism as
@@ -63,6 +86,10 @@ it's not reinvented per hub.
 10. Decide exactly one of two: SEAL (every criterion has citable
     evidence) or REOPEN (even one important gap is enough).
 11. Only on SEAL: update the ratchet/PM status in `haven/diagrams/`.
+    [added 2026-09-06] Update the node's own row IN PLACE (state column →
+    SEALED) — never reorder, move, or re-sort rows in the table
+    (`AppendOnly`); this keeps `agent-hub/.gitattributes`' `merge=union`
+    able to merge cleanly across branches.
 12. Write the verdict to
     `evidence/verifier/<date>-<slug>-{seal|reopen}.md` (flat file,
     matches the convention used across every prior evidence note).
@@ -87,7 +114,8 @@ it's not reinvented per hub.
    rest of `evidence/`.
 
 ## Hard rules honored
-`NeverVerifyOwnWork` | `EvidenceOnly` | `VerdictOnly` | `RatchetOnly` | `NoMainEdit`
+`NeverVerifyOwnWork` | `EvidenceOnly` | `VerdictOnly` | `RatchetOnly` |
+`NoMainEdit` | `AppendOnly`
 
 ## Failure branches
 | Failure | Handling |
@@ -99,4 +127,8 @@ it's not reinvented per hub.
 ## Runtime
 `/worker verifier "<task or note>"`. Prefer spawning a fresh subagent for
 this pass — it naturally satisfies `NeverVerifyOwnWork` without needing
-the operator to explicitly request a separate session.
+the operator to explicitly request a separate session. [added 2026-09-06]
+`/worker verifier "<path1> <path2> ..."` (multiple evidence note paths)
+or `/worker verifier all-pending` spawns ONE subagent that verifies every
+queued node independently — use this after several small implementer
+passes have piled up, instead of one `/worker verifier` call per node.


### PR DESCRIPTION
Operator-authored hub tooling changes, shipped at their request:

- `/worker verifier`: accept multiple evidence note paths or
  `all-pending` (every node currently `sealed_pending_verifier`) to
  amortize subagent-spawn/context-load cost across N nodes — each node
  still gets its own independent verdict from its own evidence.
- implementer/verifier manifests + `pick_next`/`verify_seal` recipes
  updated to match.
- New `/persona-load` skill (on-demand expert-persona/panel loader,
  advisory-only, read-only, no side effects).
- `agent-hub/.gitattributes`: `merge=union` for `*.prime-mermaid.md`
  diagrams (reduces merge-conflict noise on the append-only PM tables).

No `src/` changes — hub/tooling only, no build-affecting diff (build
re-verified green regardless, per `/ship`'s gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)